### PR TITLE
Native ffmpeg electron notemp

### DIFF
--- a/electron/electron/main.js
+++ b/electron/electron/main.js
@@ -1,4 +1,4 @@
-const { app, BrowserWindow, ipcMain } = require('electron');
+const { app, BrowserWindow, ipcMain, protocol } = require('electron');
 const fs = require('fs')
 const path = require('path');
 const url = require('url');
@@ -30,7 +30,16 @@ function createWindow () {
   });
 }
 
-app.on('ready', createWindow);
+app.on('ready', () => {
+  protocol.interceptFileProtocol('file', (request, callback) => {
+	const url = request.url.substr(7);
+	callback({
+		path: path.normalize(`${__dirname}/${url}`)
+	})}, (err) => {
+	  if (err) console.error('Failed to register protocol')
+	})
+  createWindow()
+});
 
 app.on('window-all-closed', function () {
   if (process.platform !== 'darwin') {

--- a/electron/electron/main.js
+++ b/electron/electron/main.js
@@ -109,6 +109,49 @@ ipcMain.on(channels.FFMPEG_TRIM, (event, {sliderval, duration, file}) => {
   });
 });
 
+ipcMain.on(channels.GET_IMG, (event, {sliderval, duration, file}) => {
+  let from = sliderval[0]/100 * duration;
+  output = require('path').dirname(file) + '\\output.png';
+  console.log('get_img');
+  console.log(from)
+  let args = [
+	'-nostdin',
+	'-y',
+	'-hide_banner',
+	'-i',
+	file,
+	'-ss',
+	from,
+	'-vframes',
+	'1',
+	'-an',
+	'-vf',
+	'scale=45:-1',
+	'-c:v',
+	'png',
+	'-f',
+	'image2pipe',
+	'pipe:1',
+	]
+
+  var proc = spawn(ffmpegPath, args)
+
+  proc.stdout.on('data', function(data) {
+    console.log(data);
+	fs.writeFileSync(file, data);
+  });
+
+  proc.stderr.setEncoding("utf8");
+  proc.stderr.on('data', function(data) {
+	console.log(data)
+	//fs.writeFileSync(file, data);
+  });
+
+  proc.on('close', () => {
+    console.log('finished');
+  });
+});
+
 ipcMain.on(channels.SET_TEMP_VIDEO, (event, {file}) => {
   fs.renameSync(output, file);
   console.log("written to" + path);

--- a/electron/electron/main.js
+++ b/electron/electron/main.js
@@ -76,9 +76,8 @@ ipcMain.on(channels.FFMPEG_TRIM, (event, {sliderval, duration, file}) => {
 	output,
 	]
 
-  console.log("spawning: " + file + " from " + ffmpegPath)
   var proc = spawn(ffmpegPath, args)
-  console.log("spawned: " + file + " from " + ffmpegPath)
+
   proc.stdout.on('data', function(data) {
     console.log(data);
 	fs.writeFileSync(file, data);
@@ -89,8 +88,10 @@ ipcMain.on(channels.FFMPEG_TRIM, (event, {sliderval, duration, file}) => {
 	console.log(data)
 	//fs.writeFileSync(file, data);
   });
+
   proc.on('close', () => {
     var output_video = fs.readFileSync(output);
+	fs.renameSync(output, file);
 	event.sender.send(channels.FFMPEG_TRIM, {
 	  out: output_video,
 	});

--- a/electron/electron/main.js
+++ b/electron/electron/main.js
@@ -29,16 +29,7 @@ function createWindow () {
   });
 }
 
-app.on('ready', () => {
-  protocol.interceptFileProtocol('file', (request, callback) => {
-	const url = request.url.substr(7);
-	callback({
-		path: path.normalize(`${__dirname}/${url}`)
-	})}, (err) => {
-	  if (err) console.error('Failed to register protocol')
-	})
-  createWindow()
-});
+app.on('ready', createWindow);
 
 app.on('window-all-closed', function () {
   if (process.platform !== 'darwin') {
@@ -65,8 +56,8 @@ ipcMain.on(channels.WRITE_VIDEO_FILE, (event, {path, file}) => {
 });
 
 ipcMain.on(channels.FFMPEG_TRIM, (event, {sliderval, duration, file}) => {
-  let from = sliderval[0]/100 * duration;
-  let to = sliderval[1]/100 * duration;
+  let from = sliderval[0]
+  let to = sliderval[1]
   output = require('path').dirname(file) + '\\output.mov';
   let args = [
 	'-nostdin',
@@ -108,7 +99,7 @@ ipcMain.on(channels.FFMPEG_TRIM, (event, {sliderval, duration, file}) => {
 });
 
 ipcMain.on(channels.GET_IMG, (event, {sliderval, duration, file}) => {
-  let from = sliderval[0]/100 * duration;
+  let from = sliderval[0]
   output = require('path').dirname(file) + '\\output.png';
   console.log('get_img');
   console.log(from)

--- a/electron/electron/main.js
+++ b/electron/electron/main.js
@@ -6,6 +6,7 @@ const { channels } = require('../src/shared/constants');
 const { spawn } = require('child_process');
 const ffmpegPath = require('ffmpeg-static');
 
+let output;
 
 let mainWindow;
 
@@ -58,7 +59,7 @@ ipcMain.on(channels.WRITE_VIDEO_FILE, (event, {path, file}) => {
 ipcMain.on(channels.FFMPEG_TRIM, (event, {sliderval, duration, file}) => {
   let from = sliderval[0]/100 * duration;
   let to = sliderval[1]/100 * duration;
-  let output = require('path').dirname(file) + '\\output.mov';
+  output = require('path').dirname(file) + '\\output.mov';
   let args = [
 	'-nostdin',
 	'-y',
@@ -90,11 +91,16 @@ ipcMain.on(channels.FFMPEG_TRIM, (event, {sliderval, duration, file}) => {
   });
 
   proc.on('close', () => {
-    var output_video = fs.readFileSync(output);
-	fs.renameSync(output, file);
+    fs.renameSync(output, file);
+    var output_video = fs.readFileSync(file);
 	event.sender.send(channels.FFMPEG_TRIM, {
 	  out: output_video,
 	});
     console.log('finished');
   });
+});
+
+ipcMain.on(channels.SET_TEMP_VIDEO, (event, {file}) => {
+  fs.renameSync(output, file);
+  console.log("written to" + path);
 });

--- a/electron/electron/main.js
+++ b/electron/electron/main.js
@@ -4,10 +4,9 @@ const path = require('path');
 const url = require('url');
 const { channels } = require('../src/shared/constants');
 const { spawn } = require('child_process');
-const ffmpegPath = require('ffmpeg-static');
+const ffmpegPath = require('ffmpeg-static').replace('app.asar', 'app.asar.unpacked');
 
 let output;
-
 let mainWindow;
 
 function createWindow () {
@@ -100,8 +99,7 @@ ipcMain.on(channels.FFMPEG_TRIM, (event, {sliderval, duration, file}) => {
   });
 
   proc.on('close', () => {
-    fs.renameSync(output, file);
-    var output_video = fs.readFileSync(file);
+    var output_video = fs.readFileSync(output);
 	event.sender.send(channels.FFMPEG_TRIM, {
 	  out: output_video,
 	});

--- a/electron/package-lock.json
+++ b/electron/package-lock.json
@@ -2322,6 +2322,14 @@
         }
       }
     },
+    "agent-base": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.0.tgz",
+      "integrity": "sha512-j1Q7cSCqN+AwrmDd+pzgqc0/NpC655x2bUf5ZjRIO77DcNBFmh+OgRNzF6OKdCC9RSCb19fGd99+bhXFdkRNqw==",
+      "requires": {
+        "debug": "4"
+      }
+    },
     "aggregate-error": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.0.1.tgz",
@@ -5828,8 +5836,7 @@
     "env-paths": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.0.tgz",
-      "integrity": "sha512-6u0VYSCo/OW6IoD5WCLLy9JUGARbamfSavcNXry/eu8aHVFei6CD3Sw+VGX5alea1i9pgPHW0mbu6Xj0uBh7gA==",
-      "dev": true
+      "integrity": "sha512-6u0VYSCo/OW6IoD5WCLLy9JUGARbamfSavcNXry/eu8aHVFei6CD3Sw+VGX5alea1i9pgPHW0mbu6Xj0uBh7gA=="
     },
     "errno": {
       "version": "0.1.7",
@@ -6819,6 +6826,17 @@
         "pend": "~1.2.0"
       }
     },
+    "ffmpeg-static": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/ffmpeg-static/-/ffmpeg-static-4.2.5.tgz",
+      "integrity": "sha512-4JykaxRgU5z/GfL0YLkBetJyXgaQXh67etMJlJMMTTcoA33voU6y/KFMg/RUehBj3DGDIs9HYhf7tozwabibaQ==",
+      "requires": {
+        "env-paths": "^2.2.0",
+        "http-basic": "github:derhuerst/http-basic#8.2.0",
+        "https-proxy-agent": "^5.0.0",
+        "progress": "^2.0.3"
+      }
+    },
     "figgy-pudding": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.2.tgz",
@@ -7681,6 +7699,16 @@
         }
       }
     },
+    "http-basic": {
+      "version": "github:derhuerst/http-basic#0abee462a1e04a1cdada369b1a4d5b2d4698e3bc",
+      "from": "github:derhuerst/http-basic#8.2.0",
+      "requires": {
+        "caseless": "^0.12.0",
+        "concat-stream": "^1.6.2",
+        "http-response-object": "^3.0.1",
+        "parse-cache-control": "^1.0.1"
+      }
+    },
     "http-cache-semantics": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
@@ -7737,6 +7765,21 @@
         "micromatch": "^3.1.10"
       }
     },
+    "http-response-object": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/http-response-object/-/http-response-object-3.0.2.tgz",
+      "integrity": "sha512-bqX0XTF6fnXSQcEJ2Iuyr75yVakyjIDCqroJQ/aHfSdlM743Cwqoi2nDYMzLGWUcuTWGWy8AAvOKXTfiv6q9RA==",
+      "requires": {
+        "@types/node": "^10.0.3"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "10.17.26",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.26.tgz",
+          "integrity": "sha512-myMwkO2Cr82kirHY8uknNRHEVtn0wV3DTQfkrjx17jmkstDRZ24gNUdl8AHXVyVclTYI/bNjgTPTAWvWLqXqkw=="
+        }
+      }
+    },
     "http-signature": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
@@ -7751,6 +7794,15 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
       "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM="
+    },
+    "https-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+      "requires": {
+        "agent-base": "6",
+        "debug": "4"
+      }
     },
     "hyphenate-style-name": {
       "version": "1.0.3",
@@ -10516,6 +10568,11 @@
         "pbkdf2": "^3.0.3",
         "safe-buffer": "^5.1.1"
       }
+    },
+    "parse-cache-control": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parse-cache-control/-/parse-cache-control-1.0.1.tgz",
+      "integrity": "sha1-juqz5U+laSD+Fro493+iGqzC104="
     },
     "parse-json": {
       "version": "4.0.0",

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "electron-cra-example",
+  "name": "electron-trim-app",
   "version": "0.1.0",
-  "productName": "Electron Create React App Example",
+  "productName": "Trim App",
   "main": "electron/main.js",
   "private": true,
   "dependencies": {
@@ -32,6 +32,9 @@
     "eject": "react-scripts eject"
   },
   "build": {
+    "asarUnpack": [
+	  "**/app/node_modules/ffmpeg-static/*"
+	],
     "files": [
       "build/**/*",
       "node_modules/**/*"

--- a/electron/package.json
+++ b/electron/package.json
@@ -12,6 +12,7 @@
     "@testing-library/react": "^9.5.0",
     "@testing-library/user-event": "^7.2.1",
     "axios": "^0.19.2",
+    "ffmpeg-static": "^4.2.5",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-router-dom": "^5.2.0",

--- a/electron/src/pages/Load.js
+++ b/electron/src/pages/Load.js
@@ -65,10 +65,12 @@ class Load extends Component {
       videos: [],
 	  currPath: '',
       sliderValue: [0,100],
+	  playbackRate: 1,
       sliderSet: false,
       status: 'pending'
     };
-
+	
+	window.addEventListener('keydown', this.handleOnKeyDown);
     //this.loadFFmpeg()
     this.handleLoadVideo = this.handleLoadVideo.bind(this);
     this.handleUpdateVideo = this.handleUpdateVideo.bind(this);
@@ -83,6 +85,12 @@ class Load extends Component {
 	const file = this.state.videos[0][1]
 
 	let videos = [];
+	
+	ipcRenderer.send(channels.GET_IMG, {
+	  sliderval: sliderval,
+	  duration: duration,
+	  file: this.state.currPath,
+	});
 	
 	ipcRenderer.send(channels.FFMPEG_TRIM, {
 	  sliderval: sliderval,
@@ -108,6 +116,14 @@ class Load extends Component {
 	
   }
 
+  handleOnKeyDown = (e) => {
+	if (e.key === 'k' && this.refs.vidRef) {
+		this.refs.vidRef.playbackRate += 0.25;
+		console.log(this.refs.vidRef.playbackRate)
+	}
+//	console.log(e.key);
+  }
+
   handleTrim(event) {
     console.log(this.state.videos)
     console.log(this.state.videos[0][1])
@@ -121,7 +137,6 @@ class Load extends Component {
     else
         newDuration = (value[1]/100) * newDuration
     this.refs.vidRef.currentTime = newDuration 
-    console.log(newDuration)
   }
 
   handleSliderValue(event, value) {

--- a/electron/src/pages/Load.js
+++ b/electron/src/pages/Load.js
@@ -69,6 +69,8 @@ class Load extends Component {
       sliderSet: false,
       status: 'pending'
     };
+
+	this.videoRef = null
 	
 	window.addEventListener('keydown', this.handleOnKeyDown);
     //this.loadFFmpeg()
@@ -79,8 +81,21 @@ class Load extends Component {
     this.handleTrim = this.handleTrim.bind(this);
   }
 
+  vidRef = ref => {
+	this.videoRef = ref;
+
+	if(this.videoRef != null) {
+	  this.videoRef.addEventListener('durationchange', this.onVideoLoad);
+	}
+  }
+
+  onVideoLoad = () => {
+	this.setState({status: 'loaded'});
+	console.log(this.videoRef.duration);
+  }
+
   trimFFmpeg() {
-	const duration = this.refs.vidRef.duration
+	const duration = this.videoRef.duration
 	const sliderval = this.state.sliderValue
 	const file = this.state.videos[0][1]
 
@@ -121,9 +136,9 @@ class Load extends Component {
   }
 
   handleOnKeyDown = (e) => {
-	if (e.key === 'k' && this.refs.vidRef) {
-		this.refs.vidRef.playbackRate += 0.25;
-		console.log(this.refs.vidRef.playbackRate)
+	if (e.key === 'k' && this.videoRef) {
+		this.videoRef.playbackRate += 0.25;
+		console.log(this.videoRef.playbackRate)
 	}
 //	console.log(e.key);
   }
@@ -135,12 +150,12 @@ class Load extends Component {
   }
 
   handleUpdateVideo(event, value) {
-    let newDuration = this.refs.vidRef.duration
-    if (this.state.sliderValue[0] != value[0])
-        newDuration = (value[0]/100) * newDuration
-    else
-        newDuration = (value[1]/100) * newDuration
-    this.refs.vidRef.currentTime = newDuration 
+	if (value[0] != this.state.sliderValue[0]) {
+	  this.videoRef.currentTime = value[0];
+	} else {
+	  this.videoRef.currentTime = value[1];
+	}
+	console.log(value);
   }
 
   handleSliderValue(event, value) {
@@ -164,7 +179,7 @@ class Load extends Component {
       ...state,
       videos,
 	  currPath: path,
-      status: 'loaded'
+     // status: 'loaded'
     }));
     console.log(this.state.videos)
     
@@ -183,7 +198,7 @@ class Load extends Component {
   renderVideo() {
     return this.state.videos.map(video => {
       return (
-        <video key={video[0]} ref="vidRef" width="100%" height="auto" controls>
+        <video key={video[0]} ref={this.vidRef} width="100%" height="auto" preload="metadata" controls>
           <source src={video[0]}/>
         </video>
       );
@@ -194,14 +209,16 @@ class Load extends Component {
     return (
       <Grid container key={this.state.sliderSet} alignItems="center" justify="center" spacing={2}>
           <Grid item xs>
-            <IconButton onClick={() => {this.refs.vidRef.play()}}>
+            <IconButton onClick={() => {this.videoRef.play()}}>
               <PlayArrowIcon variant="contained" style={{fontSize:40}}/>
             </IconButton>
           </Grid>
           <Grid item xs={9}>
             <VideoSlider 
                 ThumbComponent={VideoThumbComponent}
-                defaultValue={[0,100]}    
+                defaultValue={[0,this.videoRef.duration]}    
+				max={this.videoRef.duration}
+				step={parseFloat((this.videoRef.duration/100).toPrecision(3))}
                 onChange={this.handleUpdateVideo}
                 onChangeCommitted={this.handleSliderValue}
             />

--- a/electron/src/pages/Load.js
+++ b/electron/src/pages/Load.js
@@ -85,13 +85,14 @@ class Load extends Component {
 	const file = this.state.videos[0][1]
 
 	let videos = [];
-	
+
+/*
 	ipcRenderer.send(channels.GET_IMG, {
 	  sliderval: sliderval,
 	  duration: duration,
 	  file: this.state.currPath,
 	});
-	
+*/	
 	ipcRenderer.send(channels.FFMPEG_TRIM, {
 	  sliderval: sliderval,
 	  duration: duration,
@@ -112,6 +113,9 @@ class Load extends Component {
 		sliderSet: (!this.state.sliderSet),
 		status: 'loaded'
 	  }));
+	  ipcRenderer.send(channels.SET_TEMP_VIDEO, {
+		file: this.state.currPath,
+	  });
 	});
 	
   }

--- a/electron/src/pages/Load.js
+++ b/electron/src/pages/Load.js
@@ -105,6 +105,7 @@ class Load extends Component {
 		status: 'loaded'
 	  }));
 	});
+	
   }
 
   handleTrim(event) {

--- a/electron/src/pages/Load.js
+++ b/electron/src/pages/Load.js
@@ -63,6 +63,7 @@ class Load extends Component {
 
     this.state = {
       videos: [],
+	  currPath: '',
       sliderValue: [0,100],
       sliderSet: false,
       status: 'pending'
@@ -77,36 +78,18 @@ class Load extends Component {
   }
 
   trimFFmpeg() {
-    /*
-	await ffmpeg.write('temp.mov', this.state.videos[0][1])
-    let from = this.state.sliderValue[0]/100 * this.refs.vidRef.duration
-    let to = this.state.sliderValue[1]/100 * this.refs.vidRef.duration
-    await ffmpeg.run("-nostdin -hide_banner -i temp.mov -ss " + from + " -to " + to + " -c:v copy -c:a copy output.mov")
-    const data = ffmpeg.read('output.mov');
-
-    console.log(data)
-    const videos = [] 
-    const blob = URL.createObjectURL(new Blob([data.buffer],{ type: 'video/quicktime' }))
-*/
 	const duration = this.refs.vidRef.duration
 	const sliderval = this.state.sliderValue
 	const file = this.state.videos[0][1]
 
 	let videos = [];
+	
 	ipcRenderer.send(channels.FFMPEG_TRIM, {
 	  sliderval: sliderval,
 	  duration: duration,
-	  file: file.path,
+	  file: this.state.currPath,
 	});
-	/*
-	if (IS_ELECTRON) {
-		// Save into fs
-		ipcRenderer.send(channels.WRITE_VIDEO_FILE, {
-		  path: this.state.videos[0][1].path,
-		  file: Buffer(data.buffer),
-		})
-	}
-	*/
+	
 	ipcRenderer.on(channels.FFMPEG_TRIM, (event, arg) => {
       ipcRenderer.removeAllListeners(channels.FFMPEG_TRIM);
 	  const { out } = arg;
@@ -149,15 +132,18 @@ class Load extends Component {
 
   handleLoadVideo(event) {
     const videos = []
+	let path = '';
 
     for (const file of event.target.files) {
       console.log(file)
       videos.push([URL.createObjectURL(file), file]);
+	  path = file.path;
     }
 
     this.setState(state => ({
       ...state,
       videos,
+	  currPath: path,
       status: 'loaded'
     }));
     console.log(this.state.videos)

--- a/electron/src/shared/constants.js
+++ b/electron/src/shared/constants.js
@@ -2,5 +2,6 @@ module.exports = {
   channels: {
 	APP_INFO: 'app_info',
 	WRITE_VIDEO_FILE: 'write_vid',
+	FFMPEG_TRIM: 'ffmpeg_trim',
   },
 };

--- a/electron/src/shared/constants.js
+++ b/electron/src/shared/constants.js
@@ -3,5 +3,6 @@ module.exports = {
 	APP_INFO: 'app_info',
 	WRITE_VIDEO_FILE: 'write_vid',
 	FFMPEG_TRIM: 'ffmpeg_trim',
+	SET_TEMP_VIDEO: 'set_temp_vid',
   },
 };

--- a/electron/src/shared/constants.js
+++ b/electron/src/shared/constants.js
@@ -4,5 +4,6 @@ module.exports = {
 	WRITE_VIDEO_FILE: 'write_vid',
 	FFMPEG_TRIM: 'ffmpeg_trim',
 	SET_TEMP_VIDEO: 'set_temp_vid',
+	GET_IMG: 'get_img',
   },
 };


### PR DESCRIPTION
- Uses native ffmpeg in system instead of wasm ffmpeg(works but pointless if not 100% web)
- No longer need to calculate duration at every drag of the slider
- Directly trims video on input path without having to save and restore temps in the fs
Note: Renaming the videos still seem to cause issues (lack of permissions or readFileSync has file opened)
